### PR TITLE
chore: regenerate cloudwatch controller with latest controller-runtime

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2023-08-04T16:51:02Z"
-  build_hash: e9b68590da73ce9143ba1e4361cebdc1d876c81e
-  go_version: go1.20.7
-  version: v0.26.1-7-ge9b6859-dirty
+  build_date: "2023-12-14T22:37:33Z"
+  build_hash: 1f16813c807af6889060b4ce7ded2a69dc027d8c
+  go_version: go1.21.4
+  version: v0.27.1-9-g1f16813
 api_directory_checksum: e21bfad36ac581912d611c9c390ab4bd2c2fb46d
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.303

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -85,13 +85,14 @@ func main() {
 	}
 
 	mgr, err := ctrlrt.NewManager(ctrlrt.GetConfigOrDie(), ctrlrt.Options{
-		Scheme:             scheme,
-		Port:               port,
-		Host:               host,
-		MetricsBindAddress: ackCfg.MetricsAddr,
-		LeaderElection:     ackCfg.EnableLeaderElection,
-		LeaderElectionID:   awsServiceAPIGroup,
-		Namespace:          ackCfg.WatchNamespace,
+		Scheme:                  scheme,
+		Port:                    port,
+		Host:                    host,
+		MetricsBindAddress:      ackCfg.MetricsAddr,
+		LeaderElection:          ackCfg.EnableLeaderElection,
+		LeaderElectionID:        "ack-" + awsServiceAPIGroup,
+		Namespace:               ackCfg.WatchNamespace,
+		LeaderElectionNamespace: ackCfg.LeaderElectionNamespace,
 	})
 	if err != nil {
 		setupLog.Error(

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -29,14 +29,16 @@ spec:
         - "$(AWS_REGION)"
         - --aws-endpoint-url
         - "$(AWS_ENDPOINT_URL)"
-        - --enable-development-logging
-        - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
+        - --enable-development-logging=$(ACK_ENABLE_DEVELOPMENT_LOGGING)
         - --log-level
         - "$(ACK_LOG_LEVEL)"
         - --resource-tags
         - "$(ACK_RESOURCE_TAGS)"
         - --watch-namespace
         - "$(ACK_WATCH_NAMESPACE)"
+        - --enable-leader-election=$(ENABLE_LEADER_ELECTION)
+        - --leader-election-namespace
+        - "$(LEADER_ELECTION_NAMESPACE)"
         image: controller:latest
         name: controller
         ports:
@@ -66,6 +68,10 @@ spec:
           value: "info"
         - name: ACK_RESOURCE_TAGS
           value: "services.k8s.aws/controller-version=%CONTROLLER_SERVICE%-%CONTROLLER_VERSION%,services.k8s.aws/namespace=%K8S_NAMESPACE%"
+        - name: ENABLE_LEADER_ELECTION
+          value: "false"
+        - name: LEADER_ELECTION_NAMESPACE
+          value: "ack-system"
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
@@ -79,5 +85,6 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: ack-cloudwatch-controller
       hostIPC: false
-      hostNetwork: false
       hostPID: false
+      hostNetwork: false
+      dnsPolicy: ClusterFirst

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - role-reader.yaml
 - role-writer.yaml
 - service-account.yaml
-
+- leader-election-role.yaml
+- leader-election-role-binding.yaml

--- a/config/rbac/leader-election-role-binding.yaml
+++ b/config/rbac/leader-election-role-binding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: ack-system
+  name: cloudwatch-leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloudwatch-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: ack-cloudwatch-controller
+  namespace: ack-system

--- a/config/rbac/leader-election-role.yaml
+++ b/config/rbac/leader-election-role.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloudwatch-leader-election-role
+  namespace: ack-system
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     k8s-app: {{ include "app.name" . }}
     helm.sh/chart: {{ include "chart.name-version" . }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "app.name" . }}
@@ -48,8 +48,9 @@ spec:
         - "$(AWS_REGION)"
         - --aws-endpoint-url
         - "$(AWS_ENDPOINT_URL)"
+{{- if .Values.log.enable_development_logging }}
         - --enable-development-logging
-        - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
+{{- end }}
         - --log-level
         - "$(ACK_LOG_LEVEL)"
         - --resource-tags
@@ -58,6 +59,11 @@ spec:
         - "$(ACK_WATCH_NAMESPACE)"
         - --deletion-policy
         - "$(DELETION_POLICY)"
+{{- if .Values.leaderElection.enabled }}
+        - --enable-leader-election
+        - --leader-election-namespace
+        - "$(LEADER_ELECTION_NAMESPACE)"
+{{- end }}
 {{- if gt .Values.reconcile.defaultResyncPeriod 0.0 }}
         - --reconcile-default-resync-seconds
         - "$(RECONCILE_DEFAULT_RESYNC_SECONDS)"
@@ -87,8 +93,8 @@ spec:
           value: {{ include "watch-namespace" . }}
         - name: DELETION_POLICY
           value: {{ .Values.deletionPolicy }}
-        - name: ACK_ENABLE_DEVELOPMENT_LOGGING
-          value: {{ .Values.log.enable_development_logging | quote }}
+        - name: LEADER_ELECTION_NAMESPACE
+          value: {{ .Values.leaderElection.namespace | quote }}
         - name: ACK_LOG_LEVEL
           value: {{ .Values.log.level | quote }}
         - name: ACK_RESOURCE_TAGS
@@ -117,7 +123,7 @@ spec:
             readOnly: true
         {{- end }}
         {{- if .Values.deployment.extraVolumeMounts -}}
-          {{ toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}
+          {{ toYaml .Values.deployment.extraVolumeMounts | nindent 10 }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -141,14 +147,15 @@ spec:
       priorityClassName: {{ .Values.deployment.priorityClassName }}
       {{ end -}}
       hostIPC: false
-      hostNetwork: false
       hostPID: false
+      hostNetwork: {{ .Values.deployment.hostNetwork }}
+      dnsPolicy: {{ .Values.deployment.dnsPolicy }}
       volumes:
-      {{- if .Values.aws.credentials.secretName -}}
+      {{- if .Values.aws.credentials.secretName }}
         - name: {{ .Values.aws.credentials.secretName }}
           secret:
             secretName: {{ .Values.aws.credentials.secretName }}
-      {{ end -}}
+      {{- end }}
 {{- if .Values.deployment.extraVolumes }}
 {{ toYaml .Values.deployment.extraVolumes | indent 8}}
 {{- end }}

--- a/helm/templates/leader-election-role-binding.yaml
+++ b/helm/templates/leader-election-role-binding.yaml
@@ -1,0 +1,18 @@
+{{ if .Values.leaderElection.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloudwatch-leader-election-rolebinding
+{{ if .Values.leaderElection.namespace }}
+  namespace: {{ .Values.leaderElection.namespace }}
+{{ else }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloudwatch-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "service-account.name" . }}
+  namespace: {{ .Release.Namespace }}{{- end }}

--- a/helm/templates/leader-election-role.yaml
+++ b/helm/templates/leader-election-role.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.leaderElection.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloudwatch-leader-election-role
+{{ if .Values.leaderElection.namespace }}
+  namespace: {{ .Values.leaderElection.namespace }}
+{{ else }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch{{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -47,6 +47,9 @@
           "minimum": 1,
           "maximum": 65535
         },
+        "replicas": {
+          "type": "integer"
+        },
         "nodeSelector": {
           "type": "object"
         },
@@ -227,6 +230,18 @@
         },
         "resourceResyncPeriods": {
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "leaderElection": {
+      "description": "Parameter to configure the controller's leader election system.",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "string"
         }
       },
       "type": "object"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,6 +15,10 @@ deployment:
   annotations: {}
   labels: {}
   containerPort: 8080
+  # Number of Deployment replicas
+  # This determines how many instances of the controller will be running. It's recommended
+  # to enable leader election if you need to increase the number of replicas > 1
+  replicas: 1
   # Which nodeSelector to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
@@ -28,6 +32,15 @@ deployment:
   # Which priorityClassName to set?
   # See: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority
   priorityClassName: ""
+  # Specifies the hostname of the Pod.
+  # If not specified, the pod's hostname will be set to a system-defined value.
+  hostNetwork: false
+  # Set DNS policy for the pod.
+  # Defaults to "ClusterFirst".
+  # Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+  # To have DNS options set along with hostNetwork, you have to specify DNS policy
+  # explicitly to 'ClusterFirstWithHostNet'.
+  dnsPolicy: ClusterFirst
   extraVolumes: []
   extraVolumeMounts: []
 
@@ -52,7 +65,7 @@ deployment:
 # If "installScope: cluster" then these labels will be applied to ClusterRole
 role:
   labels: {}
-  
+
 metrics:
   service:
     # Set to true to automatically create a Kubernetes Service resource for the
@@ -80,7 +93,7 @@ aws:
     # Secret stringData key that contains the credentials
     secretKey: "credentials"
     # Profile used for AWS credentials
-    profile: "default"  
+    profile: "default"
 
 # log level for the controller
 log:
@@ -121,3 +134,15 @@ serviceAccount:
   name: ack-cloudwatch-controller
   annotations: {}
     # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
+
+# Configuration of the leader election. Required for running multiple instances of the
+# controller within the same cluster.
+# See https://kubernetes.io/docs/concepts/architecture/leases/#leader-election
+leaderElection:
+  # Enable Controller Leader Election. Set this to true to enable leader election
+  # for this controller.
+  enabled: false
+  # Leader election can be scoped to a specific namespace. By default, the controller
+  # will attempt to use the namespace of the service account mounted to the Controller
+  # pod.
+  namespace: ""

--- a/pkg/resource/metric_alarm/delta.go
+++ b/pkg/resource/metric_alarm/delta.go
@@ -50,8 +50,12 @@ func newResourceDelta(
 			delta.Add("Spec.ActionsEnabled", a.ko.Spec.ActionsEnabled, b.ko.Spec.ActionsEnabled)
 		}
 	}
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.AlarmActions, b.ko.Spec.AlarmActions) {
+	if len(a.ko.Spec.AlarmActions) != len(b.ko.Spec.AlarmActions) {
 		delta.Add("Spec.AlarmActions", a.ko.Spec.AlarmActions, b.ko.Spec.AlarmActions)
+	} else if len(a.ko.Spec.AlarmActions) > 0 {
+		if !ackcompare.SliceStringPEqual(a.ko.Spec.AlarmActions, b.ko.Spec.AlarmActions) {
+			delta.Add("Spec.AlarmActions", a.ko.Spec.AlarmActions, b.ko.Spec.AlarmActions)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.AlarmDescription, b.ko.Spec.AlarmDescription) {
 		delta.Add("Spec.AlarmDescription", a.ko.Spec.AlarmDescription, b.ko.Spec.AlarmDescription)
@@ -74,8 +78,12 @@ func newResourceDelta(
 			delta.Add("Spec.DatapointsToAlarm", a.ko.Spec.DatapointsToAlarm, b.ko.Spec.DatapointsToAlarm)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Dimensions, b.ko.Spec.Dimensions) {
+	if len(a.ko.Spec.Dimensions) != len(b.ko.Spec.Dimensions) {
 		delta.Add("Spec.Dimensions", a.ko.Spec.Dimensions, b.ko.Spec.Dimensions)
+	} else if len(a.ko.Spec.Dimensions) > 0 {
+		if !reflect.DeepEqual(a.ko.Spec.Dimensions, b.ko.Spec.Dimensions) {
+			delta.Add("Spec.Dimensions", a.ko.Spec.Dimensions, b.ko.Spec.Dimensions)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.EvaluateLowSampleCountPercentile, b.ko.Spec.EvaluateLowSampleCountPercentile) {
 		delta.Add("Spec.EvaluateLowSampleCountPercentile", a.ko.Spec.EvaluateLowSampleCountPercentile, b.ko.Spec.EvaluateLowSampleCountPercentile)
@@ -98,8 +106,12 @@ func newResourceDelta(
 			delta.Add("Spec.ExtendedStatistic", a.ko.Spec.ExtendedStatistic, b.ko.Spec.ExtendedStatistic)
 		}
 	}
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.InsufficientDataActions, b.ko.Spec.InsufficientDataActions) {
+	if len(a.ko.Spec.InsufficientDataActions) != len(b.ko.Spec.InsufficientDataActions) {
 		delta.Add("Spec.InsufficientDataActions", a.ko.Spec.InsufficientDataActions, b.ko.Spec.InsufficientDataActions)
+	} else if len(a.ko.Spec.InsufficientDataActions) > 0 {
+		if !ackcompare.SliceStringPEqual(a.ko.Spec.InsufficientDataActions, b.ko.Spec.InsufficientDataActions) {
+			delta.Add("Spec.InsufficientDataActions", a.ko.Spec.InsufficientDataActions, b.ko.Spec.InsufficientDataActions)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MetricName, b.ko.Spec.MetricName) {
 		delta.Add("Spec.MetricName", a.ko.Spec.MetricName, b.ko.Spec.MetricName)
@@ -108,8 +120,12 @@ func newResourceDelta(
 			delta.Add("Spec.MetricName", a.ko.Spec.MetricName, b.ko.Spec.MetricName)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Metrics, b.ko.Spec.Metrics) {
+	if len(a.ko.Spec.Metrics) != len(b.ko.Spec.Metrics) {
 		delta.Add("Spec.Metrics", a.ko.Spec.Metrics, b.ko.Spec.Metrics)
+	} else if len(a.ko.Spec.Metrics) > 0 {
+		if !reflect.DeepEqual(a.ko.Spec.Metrics, b.ko.Spec.Metrics) {
+			delta.Add("Spec.Metrics", a.ko.Spec.Metrics, b.ko.Spec.Metrics)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
@@ -125,8 +141,12 @@ func newResourceDelta(
 			delta.Add("Spec.Namespace", a.ko.Spec.Namespace, b.ko.Spec.Namespace)
 		}
 	}
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.OKActions, b.ko.Spec.OKActions) {
+	if len(a.ko.Spec.OKActions) != len(b.ko.Spec.OKActions) {
 		delta.Add("Spec.OKActions", a.ko.Spec.OKActions, b.ko.Spec.OKActions)
+	} else if len(a.ko.Spec.OKActions) > 0 {
+		if !ackcompare.SliceStringPEqual(a.ko.Spec.OKActions, b.ko.Spec.OKActions) {
+			delta.Add("Spec.OKActions", a.ko.Spec.OKActions, b.ko.Spec.OKActions)
+		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Period, b.ko.Spec.Period) {
 		delta.Add("Spec.Period", a.ko.Spec.Period, b.ko.Spec.Period)


### PR DESCRIPTION
Description of changes:

I ran `make build-controller SERVICE=cloudwatch` against commit 1f16813c807af6889060b4ce7ded2a69dc027d8c in https://github.com/aws-controllers-k8s/code-generator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
