### PR TITLE
feat: update the recommended policy

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,1 +1,1 @@
-arn:aws:iam::aws:policy/CloudWatchFullAccess
+arn:aws:iam::aws:policy/CloudWatchFullAccessV2


### PR DESCRIPTION
Description of changes:

AWS has deprecated the old policy in favor of the V2. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/auth-and-access-control-cw.html#managed-policies-cloudwatch-CloudWatchFullAccessV2 for more details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
