### PR TITLE
tests: Ready condition rename for cloudwatch-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,3 +88,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.54.0 h1:Mxf2oUm5Skgf0sLik5otKE5+I2+0ziC1aRWZJOwRiWQ=
+github.com/gustavodiaz7722/ack-runtime v0.54.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/condition.py
+++ b/test/e2e/condition.py
@@ -22,7 +22,7 @@ import pytest
 from acktest.k8s import resource as k8s
 
 CONDITION_TYPE_ADOPTED = "ACK.Adopted"
-CONDITION_TYPE_RESOURCE_SYNCED = "ACK.ResourceSynced"
+CONDITION_TYPE_READY = "Ready"
 CONDITION_TYPE_TERMINAL = "ACK.Terminal"
 CONDITION_TYPE_RECOVERABLE = "ACK.Recoverable"
 CONDITION_TYPE_ADVISORY = "ACK.Advisory"
@@ -31,11 +31,11 @@ CONDITION_TYPE_LATE_INITIALIZED = "ACK.LateInitialized"
 
 def assert_type_status(
     ref: k8s.CustomResourceReference,
-    cond_type_match: str = CONDITION_TYPE_RESOURCE_SYNCED,
+    cond_type_match: str = CONDITION_TYPE_READY,
     cond_status_match: bool = True,
 ):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -50,7 +50,7 @@ def assert_type_status(
         k8s.wait_resource_consumed_by_controller(ref)
         condition.assert_type_status(
             ref,
-            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            condition.CONDITION_TYPE_READY,
             False)
 
     Raises:
@@ -75,7 +75,7 @@ def assert_synced_status(
     cond_status_match: bool,
 ):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -91,15 +91,15 @@ def assert_synced_status(
         condition.assert_synced_status(ref, False)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a True status.
     """
-    assert_type_status(ref, CONDITION_TYPE_RESOURCE_SYNCED, cond_status_match)
+    assert_type_status(ref, CONDITION_TYPE_READY, cond_status_match)
 
 
-def assert_synced(ref: k8s.CustomResourceReference):
+def assert_ready(ref: k8s.CustomResourceReference):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is True.
+    Ready and that the Status of this condition is True.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -112,18 +112,18 @@ def assert_synced(ref: k8s.CustomResourceReference):
         )
         k8s.create_custom_resource(ref, resource_data)
         k8s.wait_resource_consumed_by_controller(ref)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a True status.
     """
     return assert_synced_status(ref, True)
 
 
-def assert_not_synced(ref: k8s.CustomResourceReference):
+def assert_not_ready(ref: k8s.CustomResourceReference):
     """Asserts that the supplied resource has a condition of type
-    ACK.ResourceSynced and that the Status of this condition is False.
+    Ready and that the Status of this condition is False.
 
     Usage:
         from acktest.k8s import resource as k8s
@@ -136,10 +136,10 @@ def assert_not_synced(ref: k8s.CustomResourceReference):
         )
         k8s.create_custom_resource(ref, resource_data)
         k8s.wait_resource_consumed_by_controller(ref)
-        condition.assert_not_synced(ref)
+        condition.assert_not_ready(ref)
 
     Raises:
-        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        pytest.fail when Ready condition is not found or is not in
         a False status.
     """
     return assert_synced_status(ref, False)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@01a753c63b44af5f745c64d02d5f5b0ce7fef360
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@77f6bc5602557fe48e0dd157fefbd97a6aa3e54b

--- a/test/e2e/tests/test_metric_alarm.py
+++ b/test/e2e/tests/test_metric_alarm.py
@@ -74,7 +74,7 @@ class TestMetricAlarm:
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         assert metric_alarm.exists(metric_alarm_name)
         assert k8s.get_resource_exists(ref)

--- a/test/e2e/tests/test_metric_stream.py
+++ b/test/e2e/tests/test_metric_stream.py
@@ -78,7 +78,7 @@ class TestMetricStream:
         (ref, cr) = _metric_stream
         metric_stream_name = ref.name
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         assert metric_stream.exists(metric_stream_name)
         
@@ -102,7 +102,7 @@ class TestMetricStream:
         assert k8s.get_resource_exists(ref)
 
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        condition.assert_synced(ref)
+        condition.assert_ready(ref)
 
         assert metric_stream.exists(metric_stream_name)
         


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.