### PR TITLE
fix(metricalarm): sync tags via TagResource/UntagResource on update

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-24T23:28:35Z"
-  build_hash: 0a6b791fa10a6140d862be334a6891868ee588eb
+  build_date: "2026-07-23T04:11:52Z"
+  build_hash: ab6940f9c532e013d284f670e50b727102b4126d
   go_version: go1.26.5
-  version: v0.61.0
+  version: v0.61.0-2-gab6940f
 api_directory_checksum: fc4c89800fb4263204f37a5b291222112d4150cb
 api_version: v1alpha1
 aws_service_sdk_version: v1.65.0
 generator_config_info:
-  file_checksum: 08fbc160443372732f33f8d6a185682c03c3e68d
+  file_checksum: 6a57d22315c6066962e8ca088fde91c618ef7720
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -7,7 +7,7 @@ api_directory_checksum: fc4c89800fb4263204f37a5b291222112d4150cb
 api_version: v1alpha1
 aws_service_sdk_version: v1.65.0
 generator_config_info:
-  file_checksum: 6a57d22315c6066962e8ca088fde91c618ef7720
+  file_checksum: 6e0ff476fb92c0a3d86f3ef870d974d0ffb0d5d3
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -78,6 +78,8 @@ resources:
         template_path: hooks/metricalarm/sdk_read_many_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/metricalarm/sdk_delete_post_build_request.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/metricalarm/sdk_update_pre_build_request.go.tpl
   Dashboard:
     fields:
       DashboardName:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -64,6 +64,8 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
+      AlarmArn:
+        is_arn: true
     renames:
       operations:
         PutMetricAlarm:
@@ -72,6 +74,8 @@ resources:
     hooks:
       sdk_read_many_post_build_request:
         template_path: hooks/metricalarm/sdk_read_many_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/metricalarm/sdk_read_many_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/metricalarm/sdk_delete_post_build_request.go.tpl
   Dashboard:

--- a/generator.yaml
+++ b/generator.yaml
@@ -78,6 +78,8 @@ resources:
         template_path: hooks/metricalarm/sdk_read_many_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/metricalarm/sdk_delete_post_build_request.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/metricalarm/sdk_update_pre_build_request.go.tpl
   Dashboard:
     fields:
       DashboardName:

--- a/generator.yaml
+++ b/generator.yaml
@@ -64,6 +64,8 @@ resources:
       Name:
         is_primary_key: true
         is_required: true
+      AlarmArn:
+        is_arn: true
     renames:
       operations:
         PutMetricAlarm:
@@ -72,6 +74,8 @@ resources:
     hooks:
       sdk_read_many_post_build_request:
         template_path: hooks/metricalarm/sdk_read_many_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/metricalarm/sdk_read_many_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/metricalarm/sdk_delete_post_build_request.go.tpl
   Dashboard:

--- a/pkg/resource/metric_alarm/hooks.go
+++ b/pkg/resource/metric_alarm/hooks.go
@@ -1,0 +1,105 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metric_alarm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	svcapitypes "github.com/aws-controllers-k8s/cloudwatch-controller/apis/v1alpha1"
+)
+
+// syncTags reconciles the tags on a MetricAlarm by calling TagResource for tags
+// to add or update, and UntagResource for tags to remove.
+// PutMetricAlarm silently ignores the Tags field on updates to existing alarms,
+// so tag changes must be handled via the dedicated tag APIs.
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) error {
+	desiredTags := desired.ko.Spec.Tags
+	latestTags := latest.ko.Spec.Tags
+
+	// Build lookup maps
+	latestMap := make(map[string]string, len(latestTags))
+	for _, t := range latestTags {
+		if t.Key != nil {
+			latestMap[*t.Key] = aws.ToString(t.Value)
+		}
+	}
+	desiredMap := make(map[string]string, len(desiredTags))
+	for _, t := range desiredTags {
+		if t.Key != nil {
+			desiredMap[*t.Key] = aws.ToString(t.Value)
+		}
+	}
+
+	// Determine additions/updates and removals
+	var addTags []svcsdktypes.Tag
+	for k, v := range desiredMap {
+		if latestV, ok := latestMap[k]; !ok || latestV != v {
+			k, v := k, v
+			addTags = append(addTags, svcsdktypes.Tag{Key: &k, Value: &v})
+		}
+	}
+	var removeTags []string
+	for k := range latestMap {
+		if _, ok := desiredMap[k]; !ok {
+			k := k
+			removeTags = append(removeTags, k)
+		}
+	}
+
+	if len(addTags) == 0 && len(removeTags) == 0 {
+		return nil
+	}
+
+	// ARN comes from the latest (observed) resource since desired may not have status populated.
+	if latest.ko.Status.ACKResourceMetadata == nil || latest.ko.Status.ACKResourceMetadata.ARN == nil {
+		return fmt.Errorf("cannot sync tags: MetricAlarm ARN is not yet available in status")
+	}
+	arn := string(*latest.ko.Status.ACKResourceMetadata.ARN)
+
+	if len(addTags) > 0 {
+		_, err := rm.sdkapi.TagResource(ctx, &svcsdk.TagResourceInput{
+			ResourceARN: &arn,
+			Tags:        addTags,
+		})
+		rm.metrics.RecordAPICall("UPDATE", "TagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(removeTags) > 0 {
+		_, err := rm.sdkapi.UntagResource(ctx, &svcsdk.UntagResourceInput{
+			ResourceARN: &arn,
+			TagKeys:     removeTags,
+		})
+		rm.metrics.RecordAPICall("UPDATE", "UntagResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Ensure unused import is used
+var _ = svcapitypes.MetricAlarm{}

--- a/pkg/resource/metric_alarm/sdk.go
+++ b/pkg/resource/metric_alarm/sdk.go
@@ -104,6 +104,13 @@ func (rm *resourceManager) sdkFind(
 		} else {
 			ko.Spec.AlarmActions = nil
 		}
+		if elem.AlarmArn != nil {
+			if ko.Status.ACKResourceMetadata == nil {
+				ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			tmpARN := ackv1alpha1.AWSResourceName(*elem.AlarmArn)
+			ko.Status.ACKResourceMetadata.ARN = &tmpARN
+		}
 		if elem.AlarmDescription != nil {
 			ko.Spec.AlarmDescription = elem.AlarmDescription
 		} else {
@@ -332,6 +339,23 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	// DescribeAlarms does not return tags — fetch them separately.
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+		tagsInput := &svcsdk.ListTagsForResourceInput{
+			ResourceARN: aws.String(string(*ko.Status.ACKResourceMetadata.ARN)),
+		}
+		tagsResp, tagsErr := rm.sdkapi.ListTagsForResource(ctx, tagsInput)
+		rm.metrics.RecordAPICall("READ_MANY", "ListTagsForResource", tagsErr)
+		if tagsErr != nil {
+			return nil, tagsErr
+		}
+		ko.Spec.Tags = nil
+		for _, t := range tagsResp.Tags {
+			tCopy := svcapitypes.Tag{Key: t.Key, Value: t.Value}
+			ko.Spec.Tags = append(ko.Spec.Tags, &tCopy)
+		}
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/metric_alarm/sdk.go
+++ b/pkg/resource/metric_alarm/sdk.go
@@ -678,6 +678,15 @@ func (rm *resourceManager) sdkUpdate(
 	defer func() {
 		exit(err)
 	}()
+	if delta.DifferentAt("Spec.Tags") {
+		if err = rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags") {
+		return desired, nil
+	}
+
 	input, err := rm.newUpdateRequestPayload(ctx, desired, delta)
 	if err != nil {
 		return nil, err

--- a/templates/hooks/metricalarm/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/metricalarm/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,16 @@
+	// DescribeAlarms does not return tags — fetch them separately.
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+		tagsInput := &svcsdk.ListTagsForResourceInput{
+			ResourceARN: aws.String(string(*ko.Status.ACKResourceMetadata.ARN)),
+		}
+		tagsResp, tagsErr := rm.sdkapi.ListTagsForResource(ctx, tagsInput)
+		rm.metrics.RecordAPICall("READ_MANY", "ListTagsForResource", tagsErr)
+		if tagsErr != nil {
+			return nil, tagsErr
+		}
+		ko.Spec.Tags = nil
+		for _, t := range tagsResp.Tags {
+			tCopy := svcapitypes.Tag{Key: t.Key, Value: t.Value}
+			ko.Spec.Tags = append(ko.Spec.Tags, &tCopy)
+		}
+	}

--- a/templates/hooks/metricalarm/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/metricalarm/sdk_update_pre_build_request.go.tpl
@@ -1,0 +1,8 @@
+	if delta.DifferentAt("Spec.Tags") {
+		if err = rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags") {
+		return desired, nil
+	}

--- a/test/e2e/metric_alarm.py
+++ b/test/e2e/metric_alarm.py
@@ -83,7 +83,7 @@ def get_tags(metric_alarm_arn):
     c = boto3.client('cloudwatch')
     try:
         resp = c.list_tags_for_resource(
-            ResourceName=metric_alarm_arn,
+            ResourceARN=metric_alarm_arn,
         )
         return resp['Tags']
     except c.exceptions.ResourceNotFoundException:

--- a/test/e2e/resources/metric_alarm_with_tags.yaml
+++ b/test/e2e/resources/metric_alarm_with_tags.yaml
@@ -1,0 +1,17 @@
+apiVersion: cloudwatch.services.k8s.aws/v1alpha1
+kind: MetricAlarm
+metadata:
+  name: $METRIC_ALARM_NAME
+spec:
+  alarmDescription: CPU Utilization greater than or equal to 90% for 5 minutes
+  name: $METRIC_ALARM_NAME
+  comparisonOperator: GreaterThanOrEqualToThreshold
+  evaluationPeriods: 5
+  metricName: CPUUtilization
+  namespace: AWS/EC2
+  period: 60
+  statistic: Maximum
+  threshold: 90
+  tags:
+    - key: env
+      value: $TAG_VALUE


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2985

`PutMetricAlarm` silently ignores the `Tags` field when updating an existing alarm. As a result, tag changes made to a MetricAlarm CR were never propagated to AWS.

Additionally, `DescribeAlarms` does not return tags, so tags must be fetched separately via `ListTagsForResource` on every reconcile.

## Solution

This PR fixes both issues:

1. **Read path** (`sdk_read_many_post_set_output` hook, committed in prior commit): Calls `ListTagsForResource` after every `DescribeAlarms` to populate `Spec.Tags` in the observed state, enabling accurate delta detection.

2. **Write path** (this commit): Adds a `syncTags` function in `hooks.go` that is called from `sdkUpdate` whenever `Spec.Tags` differs. It calls `TagResource` to add/update tags and `UntagResource` to remove tags no longer in the spec.

3. **Short-circuit**: A `DifferentExcept("Spec.Tags")` guard prevents an unnecessary `PutMetricAlarm` call when the delta is tags-only.

## Files Changed

- `generator.yaml` — adds `sdk_update_pre_build_request` hook for MetricAlarm
- `templates/hooks/metricalarm/sdk_update_pre_build_request.go.tpl` — new hook template with tag sync and short-circuit logic
- `pkg/resource/metric_alarm/hooks.go` — new file with `syncTags` implementation
- `pkg/resource/metric_alarm/sdk.go` — regenerated with hook injected into `sdkUpdate`

## Test plan

- [x] Create MetricAlarm CR with `env: test` tag — alarm created in AWS with correct tag
- [x] Patch CR to add `team: platform` tag — AWS alarm updated via `TagResource`
- [x] Patch CR to remove `team: platform` tag — AWS alarm updated via `UntagResource`  
- [x] Tags-only update does not trigger `PutMetricAlarm` call
- [x] `ACK.ResourceSynced=True` and `Ready=True` after each reconcile
- [x] Builds cleanly with `go build ./...`
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
